### PR TITLE
Android JSON Parser Support

### DIFF
--- a/placesautocomplete/build.gradle
+++ b/placesautocomplete/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     compile "com.android.support:support-v4:${SUPPORT_LIBRARY_VERSION}"
     provided 'com.google.code.gson:gson:2.3.1'
     provided 'com.squareup.okhttp:okhttp:2.2.0'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 modifyPom {

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/json/AndroidPlacesApiJsonParser.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/json/AndroidPlacesApiJsonParser.java
@@ -1,32 +1,857 @@
 package com.seatgeek.placesautocomplete.json;
 
+import android.util.JsonReader;
+import android.util.JsonWriter;
+
+import com.seatgeek.placesautocomplete.model.AddressComponent;
+import com.seatgeek.placesautocomplete.model.AddressComponentType;
+import com.seatgeek.placesautocomplete.model.AlternativePlaceId;
+import com.seatgeek.placesautocomplete.model.DateTimePair;
+import com.seatgeek.placesautocomplete.model.DescriptionTerm;
+import com.seatgeek.placesautocomplete.model.MatchedSubstring;
+import com.seatgeek.placesautocomplete.model.OpenHours;
+import com.seatgeek.placesautocomplete.model.OpenPeriod;
 import com.seatgeek.placesautocomplete.model.Place;
+import com.seatgeek.placesautocomplete.model.PlaceDetails;
+import com.seatgeek.placesautocomplete.model.PlaceGeometry;
+import com.seatgeek.placesautocomplete.model.PlaceLocation;
+import com.seatgeek.placesautocomplete.model.PlacePhoto;
+import com.seatgeek.placesautocomplete.model.PlaceReview;
+import com.seatgeek.placesautocomplete.model.PlaceScope;
+import com.seatgeek.placesautocomplete.model.PlaceType;
 import com.seatgeek.placesautocomplete.model.PlacesAutocompleteResponse;
 import com.seatgeek.placesautocomplete.model.PlacesDetailsResponse;
+import com.seatgeek.placesautocomplete.model.RatingAspect;
+import com.seatgeek.placesautocomplete.model.Status;
+import com.seatgeek.placesautocomplete.util.ResourceUtils;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
 import java.util.List;
 
 class AndroidPlacesApiJsonParser implements PlacesApiJsonParser {
 
     @Override
-    public PlacesAutocompleteResponse autocompleteFromStream(final InputStream is) {
-        throw new UnsupportedOperationException("Not yet implemented, please have Gson on your classpath");
+    public PlacesAutocompleteResponse autocompleteFromStream(final InputStream is) throws JsonParsingException {
+        JsonReader reader = null;
+        try {
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is));
+            reader = new JsonReader(bufferedReader);
+
+            List<Place> predictions = null;
+            Status status = null;
+            String errorMessage = null;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "predictions":
+                        predictions = readPredictionsArray(reader);
+                        break;
+                    case "status":
+                        status = readStatus(reader);
+                        break;
+                    case "error_message":
+                        errorMessage = reader.nextString();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            return new PlacesAutocompleteResponse(status, errorMessage, predictions);
+        } catch (Exception e) {
+            throw new JsonParsingException(e);
+        } finally {
+            ResourceUtils.closeResourceQuietly(reader);
+        }
     }
 
     @Override
     public PlacesDetailsResponse detailsFromStream(final InputStream is) throws JsonParsingException {
-        throw new UnsupportedOperationException("Not yet implemented, please have Gson on your classpath");
+        JsonReader reader = null;
+        try {
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is));
+            reader = new JsonReader(bufferedReader);
+
+            PlaceDetails result = null;
+            Status status = null;
+            String errorMessage = null;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "result":
+                        result = readPlaceDetails(reader);
+                        break;
+                    case "status":
+                        status = readStatus(reader);
+                        break;
+                    case "error_message":
+                        errorMessage = reader.nextString();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            return new PlacesDetailsResponse(status, errorMessage, result);
+        } catch (Exception e) {
+            throw new JsonParsingException(e);
+        } finally {
+            ResourceUtils.closeResourceQuietly(reader);
+        }
     }
 
     @Override
     public List<Place> readHistoryJson(final InputStream in) throws JsonParsingException {
-        throw new UnsupportedOperationException("Not yet implemented, please have Gson on your classpath");
+        JsonReader reader = null;
+        try {
+            reader = new JsonReader(new InputStreamReader(in, "UTF-8"));
+            List<Place> places = new ArrayList<>();
+            reader.beginArray();
+            while (reader.hasNext()) {
+                places.add(readPlace(reader));
+            }
+            reader.endArray();
+            reader.close();
+            return places;
+        } catch (Exception e) {
+            throw new JsonParsingException(e);
+        } finally {
+            ResourceUtils.closeResourceQuietly(reader);
+        }
     }
 
     @Override
     public void writeHistoryJson(final OutputStream os, final List<Place> places) throws JsonWritingException {
-        throw new UnsupportedOperationException("Not yet implemented, please have Gson on your classpath");
+        JsonWriter writer = null;
+        try {
+            writer = new JsonWriter(new OutputStreamWriter(os, "UTF-8"));
+            writer.setIndent("  ");
+            writer.beginArray();
+            for (Place place : places) {
+                writePlace(writer, place);
+            }
+            writer.endArray();
+            writer.close();
+        } catch (Exception e) {
+            throw new JsonWritingException(e);
+        } finally {
+            ResourceUtils.closeResourceQuietly(writer);
+        }
+    }
+
+    void writePlace(JsonWriter writer, Place place) throws IOException {
+        writer.beginObject();
+        writer.name("description").value(place.description);
+        writer.name("place_id").value(place.place_id);
+        writer.name("matched_substrings");
+        writeMatchedSubstringsArray(writer, place.matched_substrings);
+        writer.name("terms");
+        writeDescriptionTermsArray(writer, place.terms);
+        writer.name("types");
+        writePlaceTypesArray(writer, place.types);
+        writer.endObject();
+    }
+
+    void writeMatchedSubstringsArray(JsonWriter writer, List<MatchedSubstring> matchedSubstrings) throws IOException {
+        writer.beginArray();
+        for (MatchedSubstring matchedSubstring : matchedSubstrings) {
+            writer.beginObject();
+            writer.name("length").value(matchedSubstring.length);
+            writer.name("offset").value(matchedSubstring.offset);
+            writer.endObject();
+        }
+        writer.endArray();
+    }
+
+    void writeDescriptionTermsArray(JsonWriter writer, List<DescriptionTerm> descriptionTerms) throws IOException {
+        writer.beginArray();
+        for (DescriptionTerm term : descriptionTerms) {
+            writer.beginObject();
+            writer.name("offset").value(term.offset);
+            writer.name("value").value(term.value);
+            writer.endObject();
+        }
+        writer.endArray();
+    }
+
+    void writePlaceTypesArray(JsonWriter writer, List<PlaceType> placeTypes) throws IOException {
+        writer.beginArray();
+        for (PlaceType type : placeTypes) {
+            switch (type) {
+                case ROUTE:
+                    writer.value("route");
+                    break;
+                case GEOCODE:
+                    writer.value("geocode");
+                    break;
+            }
+        }
+        writer.endArray();
+    }
+
+    List<Place> readPredictionsArray(JsonReader reader) throws IOException {
+        List<Place> predictions = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            predictions.add(readPlace(reader));
+        }
+        reader.endArray();
+        return predictions;
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    PlaceDetails readPlaceDetails(JsonReader reader) throws IOException {
+        List<AddressComponent> addressComponents = null;
+        String formattedAddress = null;
+        String formattedPhoneNumber = null;
+        String internationalPhoneNumber = null;
+        PlaceGeometry geometry = null;
+        String icon = null;
+        String name = null;
+        String placeId = null;
+        OpenHours openingHours = null;
+        boolean permanentlyClosed = false;
+        List<PlacePhoto> photos = null;
+        PlaceScope scope = null;
+        List<AlternativePlaceId> altIds = null;
+        int priceLevel = -1;
+        double rating = -1.0;
+        List<PlaceReview> reviews = null;
+        List<String> types = null;
+        String url = null;
+        String vicinity = null;
+
+        reader.beginObject();
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "address_components":
+                    addressComponents = readAddressComponentsArray(reader);
+                    break;
+                case "formatted_address":
+                    formattedAddress = reader.nextString();
+                    break;
+                case "formatted_phone_number":
+                    formattedPhoneNumber = reader.nextString();
+                    break;
+                case "international_phone_number":
+                    internationalPhoneNumber = reader.nextString();
+                    break;
+                case "geometry":
+                    geometry = readGeometry(reader);
+                    break;
+                case "icon":
+                    icon = reader.nextString();
+                    break;
+                case "name":
+                    name = reader.nextString();
+                    break;
+                case "place_id":
+                    placeId = reader.nextString();
+                    break;
+                case "opening_hours":
+                    openingHours = readOpeningHours(reader);
+                    break;
+                case "permanently_closed":
+                    permanentlyClosed = reader.nextBoolean();
+                    break;
+                case "photos":
+                    photos = readPhotosArray(reader);
+                    break;
+                case "scope":
+                    scope = readScope(reader);
+                    break;
+                case "alt_ids":
+                    altIds = readAltIdsArray(reader);
+                    break;
+                case "price_level":
+                    priceLevel = reader.nextInt();
+                    break;
+                case "rating":
+                    rating = reader.nextDouble();
+                    break;
+                case "reviews":
+                    reviews = readReviewsArray(reader);
+                    break;
+                case "types":
+                    types = readTypesArray(reader);
+                    break;
+                case "url":
+                    url = reader.nextString();
+                    break;
+                case "vicinity":
+                    vicinity = reader.nextString();
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endObject();
+        return new PlaceDetails(addressComponents,
+                formattedAddress,
+                formattedPhoneNumber,
+                internationalPhoneNumber,
+                geometry,
+                icon,
+                name,
+                placeId,
+                openingHours,
+                permanentlyClosed,
+                photos,
+                scope,
+                altIds,
+                priceLevel,
+                rating,
+                reviews,
+                types,
+                url,
+                vicinity);
+    }
+
+    List<AddressComponent> readAddressComponentsArray(JsonReader reader) throws IOException {
+        List<AddressComponent> addressComponents = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            String longName = null;
+            String shortName = null;
+            List<AddressComponentType> types = null;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "long_name":
+                        longName = reader.nextString();
+                        break;
+                    case "short_name":
+                        shortName = reader.nextString();
+                        break;
+                    case "types":
+                        types = readAddressComponentTypesArray(reader);
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            addressComponents.add(new AddressComponent(longName, shortName, types));
+        }
+        reader.endArray();
+        return addressComponents;
+    }
+
+    List<AddressComponentType> readAddressComponentTypesArray(JsonReader reader) throws IOException {
+        List<AddressComponentType> types = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            switch (reader.nextString()) {
+                case "administrative_area_level_1":
+                    types.add(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1);
+                    break;
+                case "administrative_area_level_2":
+                    types.add(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_2);
+                    break;
+                case "administrative_area_level_3":
+                    types.add(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_3);
+                    break;
+                case "administrative_area_level_4":
+                    types.add(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_4);
+                    break;
+                case "administrative_area_level_5":
+                    types.add(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_5);
+                    break;
+                case "colloquial_area":
+                    types.add(AddressComponentType.COLLOQUIAL_AREA);
+                    break;
+                case "country":
+                    types.add(AddressComponentType.COUNTRY);
+                    break;
+                case "floor":
+                    types.add(AddressComponentType.FLOOR);
+                    break;
+                case "geocode":
+                    types.add(AddressComponentType.GEOCODE);
+                    break;
+                case "intersection":
+                    types.add(AddressComponentType.INTERSECTION);
+                    break;
+                case "locality":
+                    types.add(AddressComponentType.LOCALITY);
+                    break;
+                case "natural_feature":
+                    types.add(AddressComponentType.NATURAL_FEATURE);
+                    break;
+                case "neighborhood":
+                    types.add(AddressComponentType.NEIGHBORHOOD);
+                    break;
+                case "political":
+                    types.add(AddressComponentType.POLITICAL);
+                    break;
+                case "point_of_interest":
+                    types.add(AddressComponentType.POINT_OF_INTEREST);
+                    break;
+                case "post_box":
+                    types.add(AddressComponentType.POST_BOX);
+                    break;
+                case "postal_code":
+                    types.add(AddressComponentType.POSTAL_CODE);
+                    break;
+                case "postal_code_prefix":
+                    types.add(AddressComponentType.POSTAL_CODE_PREFIX);
+                    break;
+                case "postal_code_suffix":
+                    types.add(AddressComponentType.POSTAL_CODE_SUFFIX);
+                    break;
+                case "postal_town":
+                    types.add(AddressComponentType.POSTAL_TOWN);
+                    break;
+                case "premise":
+                    types.add(AddressComponentType.PREMISE);
+                    break;
+                case "room":
+                    types.add(AddressComponentType.ROOM);
+                    break;
+                case "route":
+                    types.add(AddressComponentType.ROUTE);
+                    break;
+                case "street_address":
+                    types.add(AddressComponentType.STREET_ADDRESS);
+                    break;
+                case "street_number":
+                    types.add(AddressComponentType.STREET_NUMBER);
+                    break;
+                case "sublocality":
+                    types.add(AddressComponentType.SUBLOCALITY);
+                    break;
+                case "sublocality_level_1":
+                    types.add(AddressComponentType.SUBLOCALITY_LEVEL_1);
+                    break;
+                case "sublocality_level_2":
+                    types.add(AddressComponentType.SUBLOCALITY_LEVEL_2);
+                    break;
+                case "sublocality_level_3":
+                    types.add(AddressComponentType.SUBLOCALITY_LEVEL_3);
+                    break;
+                case "sublocality_level_4":
+                    types.add(AddressComponentType.SUBLOCALITY_LEVEL_4);
+                    break;
+                case "sublocality_level_5":
+                    types.add(AddressComponentType.SUBLOCALITY_LEVEL_5);
+                    break;
+                case "subpremise":
+                    types.add(AddressComponentType.SUBPREMISE);
+                    break;
+                case "transit_station":
+                    types.add(AddressComponentType.TRANSIT_STATION);
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endArray();
+        return types;
+    }
+
+    PlaceGeometry readGeometry(JsonReader reader) throws IOException {
+        double lat = -1.0;
+        double lng = -1.0;
+
+        reader.beginObject();
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "lat":
+                    lat = reader.nextDouble();
+                    break;
+                case "lng":
+                    lng = reader.nextDouble();
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endObject();
+        return new PlaceGeometry(new PlaceLocation(lat, lng));
+    }
+
+    OpenHours readOpeningHours(JsonReader reader) throws IOException {
+        boolean openNow = false;
+        List<OpenPeriod> periods = null;
+
+        reader.beginObject();
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "open_now":
+                    openNow = reader.nextBoolean();
+                    break;
+                case "periods":
+                    periods = readOpenPeriodsArray(reader);
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endObject();
+        return new OpenHours(openNow, periods);
+    }
+
+    List<OpenPeriod> readOpenPeriodsArray(JsonReader reader) throws IOException {
+        List<OpenPeriod> periods = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            DateTimePair open = null;
+            DateTimePair close = null;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "open":
+                        open = readDateTimePair(reader);
+                        break;
+                    case "close":
+                        close = readDateTimePair(reader);
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            periods.add(new OpenPeriod(open, close));
+        }
+        reader.endArray();
+        return periods;
+    }
+
+    DateTimePair readDateTimePair(JsonReader reader) throws IOException {
+        String day = null;
+        String time = null;
+
+        reader.beginObject();
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "day":
+                    day = reader.nextString();
+                    break;
+                case "time":
+                    time = reader.nextString();
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endObject();
+        return new DateTimePair(day, time);
+    }
+
+    List<PlacePhoto> readPhotosArray(JsonReader reader) throws IOException {
+        List<PlacePhoto> photos = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            int height = -1;
+            int width = -1;
+            String photoReference = null;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "height":
+                        height = reader.nextInt();
+                        break;
+                    case "width":
+                        width = reader.nextInt();
+                        break;
+                    case "photo_reference":
+                        photoReference = reader.nextString();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            photos.add(new PlacePhoto(height, width, photoReference));
+        }
+        reader.endArray();
+        return photos;
+    }
+
+    PlaceScope readScope(JsonReader reader) throws IOException {
+        switch (reader.nextString()) {
+            case "APP":
+                return PlaceScope.APP;
+            case "GOOGLE":
+                return PlaceScope.GOOGLE;
+            default:
+                // not possible based on API spec:
+                // https://developers.google.com/places/web-service/details#PlaceDetailsResults
+                return null;
+        }
+    }
+
+    List<AlternativePlaceId> readAltIdsArray(JsonReader reader) throws IOException {
+        List<AlternativePlaceId> altIds = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            String placeId = null;
+            PlaceScope scope = null;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "place_id":
+                        placeId = reader.nextString();
+                        break;
+                    case "scope":
+                        scope = readScope(reader);
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            altIds.add(new AlternativePlaceId(placeId, scope));
+        }
+        reader.endArray();
+        return altIds;
+    }
+
+    List<PlaceReview> readReviewsArray(JsonReader reader) throws IOException {
+        List<PlaceReview> reviews = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            List<RatingAspect> aspects = null;
+            String authorName = null;
+            String authorUrl = null;
+            String language = null;
+            int rating = -1;
+            String text = null;
+            long time = -1L;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "aspects":
+                        aspects = readAspectsArray(reader);
+                        break;
+                    case "author_name":
+                        authorName = reader.nextString();
+                        break;
+                    case "author_url":
+                        authorUrl = reader.nextString();
+                        break;
+                    case "language":
+                        language = reader.nextString();
+                        break;
+                    case "rating":
+                        rating = reader.nextInt();
+                        break;
+                    case "text":
+                        text = reader.nextString();
+                        break;
+                    case "time":
+                        time = reader.nextLong();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            reviews.add(new PlaceReview(aspects, authorName, authorUrl, language, rating, text, time));
+        }
+        reader.endArray();
+        return reviews;
+    }
+
+    List<RatingAspect> readAspectsArray(JsonReader reader) throws IOException {
+        List<RatingAspect> aspects = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            int rating = -1;
+            String type = null;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "rating":
+                        rating = reader.nextInt();
+                        break;
+                    case "type":
+                        type = reader.nextString();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            aspects.add(new RatingAspect(rating, type));
+        }
+        reader.endArray();
+        return aspects;
+    }
+
+    List<String> readTypesArray(JsonReader reader) throws IOException {
+        List<String> types = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            types.add(reader.nextString());
+        }
+        reader.endArray();
+        return types;
+    }
+
+    Status readStatus(JsonReader reader) throws IOException {
+        switch (reader.nextString()) {
+            case "OK":
+                return Status.OK;
+            case "ZERO_RESULTS":
+                return Status.ZERO_RESULTS;
+            case "OVER_QUERY_LIMIT":
+                return Status.OVER_QUERY_LIMIT;
+            case "REQUEST_DENIED":
+                return Status.REQUEST_DENIED;
+            case "INVALID_REQUEST":
+                return Status.INVALID_REQUEST;
+            default:
+                return null;
+        }
+    }
+
+    Place readPlace(JsonReader reader) throws IOException {
+        String description = null;
+        String placeId = null;
+        List<MatchedSubstring> matchedSubstrings = null;
+        List<DescriptionTerm> terms = null;
+        List<PlaceType> types = null;
+
+        reader.beginObject();
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "description":
+                    description = reader.nextString();
+                    break;
+                case "place_id":
+                    placeId = reader.nextString();
+                    break;
+                case "matched_substrings":
+                    matchedSubstrings = readMatchedSubstringsArray(reader);
+                    break;
+                case "terms":
+                    terms = readDescriptionTermsArray(reader);
+                    break;
+                case "types":
+                    types = readPlaceTypesArray(reader);
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endObject();
+        return new Place(description, placeId, matchedSubstrings, terms, types);
+    }
+
+    List<MatchedSubstring> readMatchedSubstringsArray(JsonReader reader) throws IOException {
+        List<MatchedSubstring> matchedSubstrings = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            int length = -1;
+            int offset = -1;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "length":
+                        length = reader.nextInt();
+                        break;
+                    case "offset":
+                        offset = reader.nextInt();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            matchedSubstrings.add(new MatchedSubstring(length, offset));
+        }
+        reader.endArray();
+        return matchedSubstrings;
+    }
+
+    List<DescriptionTerm> readDescriptionTermsArray(JsonReader reader) throws IOException {
+        List<DescriptionTerm> terms = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            int offset = -1;
+            String value = null;
+
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "offset":
+                        offset = reader.nextInt();
+                        break;
+                    case "value":
+                        value = reader.nextString();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            terms.add(new DescriptionTerm(offset, value));
+        }
+        reader.endArray();
+        return terms;
+    }
+
+    List<PlaceType> readPlaceTypesArray(JsonReader reader) throws IOException {
+        List<PlaceType> types = new ArrayList<>();
+
+        reader.beginArray();
+        while (reader.hasNext()) {
+            switch (reader.nextString()) {
+                case "route":
+                    types.add(PlaceType.ROUTE);
+                    break;
+                case "geocode":
+                    types.add(PlaceType.GEOCODE);
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endArray();
+        return types;
     }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/json/GsonPlacesApiJsonParser.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/json/GsonPlacesApiJsonParser.java
@@ -48,7 +48,7 @@ class GsonPlacesApiJsonParser implements PlacesApiJsonParser {
     public List<Place> readHistoryJson(final InputStream in) throws JsonParsingException {
         try {
             JsonReader reader = new JsonReader(new InputStreamReader(in, "UTF-8"));
-            List<Place> places = new ArrayList<Place>();
+            List<Place> places = new ArrayList<>();
             reader.beginArray();
             while (reader.hasNext()) {
                 Place message = gson.fromJson(reader, Place.class);

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/AddressComponent.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/AddressComponent.java
@@ -21,4 +21,26 @@ public final class AddressComponent {
                 ", types=" + types +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AddressComponent)) return false;
+
+        AddressComponent that = (AddressComponent) o;
+
+        if (long_name != null ? !long_name.equals(that.long_name) : that.long_name != null) return false;
+        if (short_name != null ? !short_name.equals(that.short_name) : that.short_name != null) return false;
+        if (types != null ? !types.equals(that.types) : that.types != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = long_name != null ? long_name.hashCode() : 0;
+        result = 31 * result + (short_name != null ? short_name.hashCode() : 0);
+        result = 31 * result + (types != null ? types.hashCode() : 0);
+        return result;
+    }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/AlternativePlaceId.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/AlternativePlaceId.java
@@ -8,4 +8,24 @@ public final class AlternativePlaceId {
         this.place_id = place_id;
         this.scope = scope;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AlternativePlaceId)) return false;
+
+        AlternativePlaceId that = (AlternativePlaceId) o;
+
+        if (place_id != null ? !place_id.equals(that.place_id) : that.place_id != null) return false;
+        if (scope != null ? !scope.equals(that.scope) : that.scope != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (place_id != null ? place_id.hashCode() : 0);
+        result = 31 * result + (scope != null ? scope.hashCode() : 0);
+        return result;
+    }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/DateTimePair.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/DateTimePair.java
@@ -15,4 +15,24 @@ public final class DateTimePair {
         this.day = day;
         this.time = time;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DateTimePair)) return false;
+
+        DateTimePair that = (DateTimePair) o;
+
+        if (day != null ? !day.equals(that.day) : that.day != null) return false;
+        if (time != null ? !time.equals(that.time) : that.time != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = day != null ? day.hashCode() : 0;
+        result = 31 * result + (time != null ? time.hashCode() : 0);
+        return result;
+    }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/OpenHours.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/OpenHours.java
@@ -10,4 +10,24 @@ public final class OpenHours {
         this.open_now = open_now;
         this.periods = periods;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OpenHours)) return false;
+
+        OpenHours that = (OpenHours) o;
+
+        if (open_now != that.open_now) return false;
+        if (periods != null ? !periods.equals(that.periods) : that.periods != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = open_now ? 1 : 0;
+        result = 31 * result + (periods != null ? periods.hashCode() : 0);
+        return result;
+    }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/OpenPeriod.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/OpenPeriod.java
@@ -8,4 +8,24 @@ public final class OpenPeriod {
         this.open = open;
         this.close = close;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OpenPeriod)) return false;
+
+        OpenPeriod that = (OpenPeriod) o;
+
+        if (open != null ? !open.equals(that.open) : that.open != null) return false;
+        if (close != null ? !close.equals(that.close) : that.close != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = open != null ? open.hashCode() : 0;
+        result = 31 * result + (close != null ? close.hashCode() : 0);
+        return result;
+    }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlaceDetails.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlaceDetails.java
@@ -1,5 +1,6 @@
 package com.seatgeek.placesautocomplete.model;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -87,5 +88,61 @@ public final class PlaceDetails {
         this.types = types;
         this.url = url;
         this.vicinity = vicinity;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PlaceDetails)) return false;
+
+        PlaceDetails that = (PlaceDetails) o;
+
+        if (address_components != null ? !address_components.equals(that.address_components) : that.address_components != null) return false;
+        if (formatted_address != null ? !formatted_address.equals(that.formatted_address) : that.formatted_address != null) return false;
+        if (formatted_phone_number != null ? !formatted_phone_number.equals(that.formatted_phone_number) : that.formatted_phone_number != null) return false;
+        if (international_phone_number != null ? !international_phone_number.equals(that.international_phone_number) : that.international_phone_number != null) return false;
+        if (geometry != null ? !geometry.equals(that.geometry) : that.geometry != null) return false;
+        if (icon != null ? !icon.equals(that.icon) : that.icon != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (place_id != null ? !place_id.equals(that.place_id) : that.place_id != null) return false;
+        if (opening_hours != null ? !opening_hours.equals(that.opening_hours) : that.opening_hours != null) return false;
+        if (permanently_closed != that.permanently_closed) return false;
+        if (photos != null ? !photos.equals(that.photos) : that.photos != null) return false;
+        if (scope != null ? !scope.equals(that.scope) : that.scope != null) return false;
+        if (alt_ids != null ? !alt_ids.equals(that.alt_ids) : that.alt_ids != null) return false;
+        if (address_components != null ? !address_components.equals(that.address_components) : that.address_components != null) return false;
+        if (price_level != that.price_level) return false;
+        if (rating != rating) return false;
+        if (reviews != null ? !reviews.equals(that.reviews) : that.reviews != null) return false;
+        if (types != null ? !types.equals(that.types) : that.types != null) return false;
+        if (url != null ? !url.equals(that.url) : that.url != null) return false;
+        if (vicinity != null ? !vicinity.equals(that.vicinity) : that.vicinity != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = address_components != null ? address_components.hashCode() : 0;
+        result = 31 * result + (formatted_address != null ? formatted_address.hashCode() : 0);
+        result = 31 * result + (formatted_phone_number != null ? formatted_phone_number.hashCode() : 0);
+        result = 31 * result + (international_phone_number != null ? international_phone_number.hashCode() : 0);
+        result = 31 * result + (geometry != null ? geometry.hashCode() : 0);
+        result = 31 * result + (icon != null ? icon.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (place_id != null ? place_id.hashCode() : 0);
+        result = 31 * result + (opening_hours != null ? opening_hours.hashCode() : 0);
+        result = 31 * result + (permanently_closed ? 1 : 0);
+        result = 31 * result + (photos != null ? photos.hashCode() : 0);
+        result = 31 * result + (scope != null ? scope.hashCode() : 0);
+        result = 31 * result + (alt_ids != null ? alt_ids.hashCode() : 0);
+        result = 31 * result + price_level;
+        long ratingBits = Double.doubleToLongBits(rating);
+        result = 31 * result + (int) (ratingBits ^ (ratingBits >>> 32));
+        result = 31 * result + (reviews != null ? reviews.hashCode() : 0);
+        result = 31 * result + (types != null ? types.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (vicinity != null ? vicinity.hashCode() : 0);
+        return result;
     }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlaceGeometry.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlaceGeometry.java
@@ -6,4 +6,21 @@ public final class PlaceGeometry {
     public PlaceGeometry(final PlaceLocation location) {
         this.location = location;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof  PlaceGeometry)) return false;
+
+        PlaceGeometry that = (PlaceGeometry) o;
+
+        if (location != null ? !location.equals(that.location) : that.location != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return location != null ? location.hashCode() : 0;
+    }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlaceLocation.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlaceLocation.java
@@ -8,4 +8,26 @@ public final class PlaceLocation {
         this.lat = lat;
         this.lng = lng;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PlaceLocation)) return false;
+
+        PlaceLocation that = (PlaceLocation) o;
+
+        if (lat != that.lat) return false;
+        if (lng != that.lng) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        long latBits = Double.doubleToLongBits(lat);
+        long lngBits = Double.doubleToLongBits(lng);
+        int result = (int) (latBits ^ (latBits >>> 32));
+        result = 31 * result + (int) (lngBits ^ (lngBits >>> 32));;
+        return result;
+    }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlacePhoto.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlacePhoto.java
@@ -10,4 +10,26 @@ public final class PlacePhoto {
         this.width = width;
         this.photo_reference = photo_reference;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PlacePhoto)) return false;
+
+        PlacePhoto that = (PlacePhoto) o;
+
+        if (height != that.height) return false;
+        if (width != that.width) return false;
+        if (photo_reference != null ? !photo_reference.equals(that.photo_reference) : that.photo_reference != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = height;
+        result = 31 * result + width;
+        result = 31 * result + (photo_reference != null ? photo_reference.hashCode() : 0);
+        return result;
+    }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlaceReview.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/PlaceReview.java
@@ -1,5 +1,76 @@
 package com.seatgeek.placesautocomplete.model;
 
+import java.util.List;
+
+/**
+ * A single review for a Place. For instance:
+ *      {
+ *          "aspects" : [
+ *              {
+ *                  "rating" : 3,
+ *                  "type" : "quality"
+ *              }
+ *          ],
+ *          "author_name" : "Simon Bengtsson",
+ *          "author_url" : "https://plus.google.com/104675092887960962573",
+ *          "language" : "en",
+ *          "rating" : 5,
+ *          "text" : "Just went inside to have a look at Google. Amazing.",
+ *          "time" : 1338440552869
+ *      }
+ */
 public final class PlaceReview {
-    // TODO
+    public final List<RatingAspect> aspects;
+    public final String author_name;
+    public final String author_url;
+    public final String language;
+    public final int rating;
+    public final String text;
+    public final long time;
+
+    public PlaceReview(final List<RatingAspect> aspects,
+                       final String author_name,
+                       final String author_url,
+                       final String language,
+                       final int rating,
+                       final String text,
+                       final long time) {
+        this.aspects = aspects;
+        this.author_name = author_name;
+        this.author_url = author_url;
+        this.language = language;
+        this.rating = rating;
+        this.text = text;
+        this.time = time;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PlaceReview)) return false;
+
+        PlaceReview that = (PlaceReview) o;
+
+        if (aspects != null ? !aspects.equals(that.aspects) : that.aspects != null) return false;
+        if (author_name != null ? !author_name.equals(that.author_name) : that.author_name != null) return false;
+        if (author_url != null ? !author_url.equals(that.author_url) : that.author_url != null) return false;
+        if (language != null ? !language.equals(that.language) : that.language != null) return false;
+        if (rating != that.rating) return false;
+        if (text != null ? !text.equals(that.text) : that.text != null) return false;
+        if (time != that.time) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = rating;
+        result = 31 * result + (aspects != null ? aspects.hashCode() : 0);
+        result = 31 * result + (author_name != null ? author_name.hashCode() : 0);
+        result = 31 * result + (author_url != null ? author_url.hashCode() : 0);
+        result = 31 * result + (language != null ? language.hashCode() : 0);
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        result = 31 * result + (int) (time ^ (time >>> 32));;
+        return result;
+    }
 }

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/RatingAspect.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/model/RatingAspect.java
@@ -1,0 +1,31 @@
+package com.seatgeek.placesautocomplete.model;
+
+public final class RatingAspect {
+    public final int rating;
+    public final String type;
+
+    public RatingAspect(final int rating, final String type) {
+        this.rating = rating;
+        this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RatingAspect)) return false;
+
+        RatingAspect that = (RatingAspect) o;
+
+        if (rating != that.rating) return false;
+        if (type != null ? !type.equals(that.type) : that.type != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = rating;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        return result;
+    }
+}

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/util/ResourceUtils.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/util/ResourceUtils.java
@@ -1,0 +1,23 @@
+package com.seatgeek.placesautocomplete.util;
+
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public final class ResourceUtils {
+
+    public static void closeResourceQuietly(@Nullable Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                Log.e(ResourceUtils.class.getName(), e.getMessage(), e);
+            }
+        }
+    }
+
+    private ResourceUtils() {
+    }
+}

--- a/placesautocomplete/src/test/java/com/seatgeek/placesautocomplete/json/AndroidPlacesApiJsonParserTest.java
+++ b/placesautocomplete/src/test/java/com/seatgeek/placesautocomplete/json/AndroidPlacesApiJsonParserTest.java
@@ -1,0 +1,373 @@
+package com.seatgeek.placesautocomplete.json;
+
+import android.util.JsonReader;
+
+import com.seatgeek.placesautocomplete.model.AddressComponent;
+import com.seatgeek.placesautocomplete.model.AddressComponentType;
+import com.seatgeek.placesautocomplete.model.AlternativePlaceId;
+import com.seatgeek.placesautocomplete.model.DateTimePair;
+import com.seatgeek.placesautocomplete.model.DescriptionTerm;
+import com.seatgeek.placesautocomplete.model.MatchedSubstring;
+import com.seatgeek.placesautocomplete.model.OpenHours;
+import com.seatgeek.placesautocomplete.model.OpenPeriod;
+import com.seatgeek.placesautocomplete.model.Place;
+import com.seatgeek.placesautocomplete.model.PlaceDetails;
+import com.seatgeek.placesautocomplete.model.PlaceGeometry;
+import com.seatgeek.placesautocomplete.model.PlaceLocation;
+import com.seatgeek.placesautocomplete.model.PlacePhoto;
+import com.seatgeek.placesautocomplete.model.PlaceReview;
+import com.seatgeek.placesautocomplete.model.PlaceScope;
+import com.seatgeek.placesautocomplete.model.PlaceType;
+import com.seatgeek.placesautocomplete.model.RatingAspect;
+import com.seatgeek.placesautocomplete.model.Status;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AndroidPlacesApiJsonParserTest {
+    private AndroidPlacesApiJsonParser parser;
+    private JsonReader reader;
+
+    @Before
+    public void setUp() {
+        parser = mock(AndroidPlacesApiJsonParser.class);
+        reader = mock(JsonReader.class);
+    }
+
+    @Test
+    public void readPlaceTypesArrayTest() throws IOException {
+        when(parser.readPlaceTypesArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, false);
+        when(reader.nextString()).thenReturn("route", "geocode", "skip");
+        List<PlaceType> expected = Arrays.asList(PlaceType.ROUTE, PlaceType.GEOCODE);
+        List<PlaceType> actual = parser.readPlaceTypesArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readDescriptionTermsArrayTest() throws IOException {
+        when(parser.readDescriptionTermsArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, true, false, true, false, false);
+        when(reader.nextName()).thenReturn("offset", "value", "skip");
+        when(reader.nextInt()).thenReturn(1);
+        when(reader.nextString()).thenReturn("one");
+        List<DescriptionTerm> expected = Arrays.asList(new DescriptionTerm(1, "one"), new DescriptionTerm(-1, null));
+        List<DescriptionTerm> actual = parser.readDescriptionTermsArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readMatchedSubstringsArrayTest() throws IOException {
+        when(parser.readMatchedSubstringsArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, true, false, true, false, false);
+        when(reader.nextName()).thenReturn("length", "offset", "skip");
+        when(reader.nextInt()).thenReturn(1, 2);
+        List<MatchedSubstring> expected = Arrays.asList(new MatchedSubstring(1, 2), new MatchedSubstring(-1, -1));
+        List<MatchedSubstring> actual = parser.readMatchedSubstringsArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readPlaceTest() throws IOException {
+        when(parser.readPlace(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, true, true, true, false);
+        when(reader.nextName()).thenReturn("description", "place_id", "matched_substrings", "terms", "types", "skip");
+        when(reader.nextString()).thenReturn("desc", "id");
+        List<MatchedSubstring> substrings = Collections.singletonList(new MatchedSubstring(1, 2));
+        when(parser.readMatchedSubstringsArray(reader)).thenReturn(substrings);
+        List<DescriptionTerm> terms = Collections.singletonList(new DescriptionTerm(3, "three"));
+        when(parser.readDescriptionTermsArray(reader)).thenReturn(terms);
+        List<PlaceType> types = Arrays.asList(PlaceType.ROUTE, PlaceType.GEOCODE);
+        when(parser.readPlaceTypesArray(reader)).thenReturn(types);
+        Place expected = new Place("desc", "id", substrings, terms, types);
+        Place actual = parser.readPlace(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readStatusTest() throws IOException {
+        when(parser.readStatus(reader)).thenCallRealMethod();
+        when(reader.nextString()).thenReturn("OK", "ZERO_RESULTS", "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", "skip");
+        assertEquals(Status.OK, parser.readStatus(reader));
+        assertEquals(Status.ZERO_RESULTS, parser.readStatus(reader));
+        assertEquals(Status.OVER_QUERY_LIMIT, parser.readStatus(reader));
+        assertEquals(Status.REQUEST_DENIED, parser.readStatus(reader));
+        assertEquals(Status.INVALID_REQUEST, parser.readStatus(reader));
+        assertNull(parser.readStatus(reader));
+    }
+
+    @Test
+    public void readTypesArrayTest() throws IOException {
+        when(parser.readTypesArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, false);
+        when(reader.nextString()).thenReturn("one", "two", "three");
+        List<String> expected = Arrays.asList("one", "two", "three");
+        List<String> actual = parser.readTypesArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readAspectsArrayTest() throws IOException {
+        when(parser.readAspectsArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, true, false, true, false, false);
+        when(reader.nextName()).thenReturn("rating", "type", "skip");
+        when(reader.nextInt()).thenReturn(1);
+        when(reader.nextString()).thenReturn("one");
+        List<RatingAspect> expected = Arrays.asList(new RatingAspect(1, "one"), new RatingAspect(-1, null));
+        List<RatingAspect> actual = parser.readAspectsArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readReviewsArrayTest() throws IOException {
+        when(parser.readReviewsArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, true, true, true, true, true, true, true, false, true, false, false);
+        when(reader.nextName()).thenReturn("aspects", "author_name", "author_url", "language", "rating", "text", "time", "skip");
+        List<RatingAspect> aspects = Arrays.asList(new RatingAspect(1, "one"), new RatingAspect(-1, null));
+        when(parser.readAspectsArray(reader)).thenReturn(aspects);
+        when(reader.nextString()).thenReturn("name", "url", "lang", "txt");
+        when(reader.nextInt()).thenReturn(1);
+        when(reader.nextLong()).thenReturn(10L);
+        List<PlaceReview> expected = Arrays.asList(new PlaceReview(aspects, "name", "url", "lang", 1, "txt", 10L), new PlaceReview(null, null, null, null, -1, null, -1L));
+        List<PlaceReview> actual = parser.readReviewsArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readAltIdsArrayTest() throws IOException {
+        when(parser.readAltIdsArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, true, false, true, false, false);
+        when(reader.nextName()).thenReturn("place_id", "scope", "skip");
+        when(reader.nextString()).thenReturn("id");
+        when(parser.readScope(reader)).thenReturn(PlaceScope.GOOGLE);
+        List<AlternativePlaceId> expected = Arrays.asList(new AlternativePlaceId("id", PlaceScope.GOOGLE), new AlternativePlaceId(null, null));
+        List<AlternativePlaceId> actual = parser.readAltIdsArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readScopeTest() throws IOException {
+        when(parser.readScope(reader)).thenCallRealMethod();
+        when(reader.nextString()).thenReturn("APP", "GOOGLE", "skip");
+        assertEquals(PlaceScope.APP, parser.readScope(reader));
+        assertEquals(PlaceScope.GOOGLE, parser.readScope(reader));
+        assertNull(parser.readScope(reader));
+    }
+
+    @Test
+    public void readPhotosArrayTest() throws IOException {
+        when(parser.readPhotosArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, true, true, false, true, false, false);
+        when((reader.nextName())).thenReturn("height", "width", "photo_reference", "skip");
+        when(reader.nextInt()).thenReturn(1, 2);
+        when(reader.nextString()).thenReturn("photo");
+        List<PlacePhoto> expected = Arrays.asList(new PlacePhoto(1, 2, "photo"), new PlacePhoto(-1, -1, null));
+        List<PlacePhoto> actual = parser.readPhotosArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readDateTimePairTest() throws IOException {
+        when(parser.readDateTimePair(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, false);
+        when((reader.nextName())).thenReturn("day", "time", "skip");
+        when((reader.nextString())).thenReturn("one", "two");
+        DateTimePair expected = new DateTimePair("one", "two");
+        DateTimePair actual = parser.readDateTimePair(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readOpenPeriodsArrayTest() throws IOException {
+        when(parser.readOpenPeriodsArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, true, false, true, false, false);
+        when(reader.nextName()).thenReturn("open", "close", "skip");
+        when(parser.readDateTimePair(reader)).thenReturn(new DateTimePair("one", "two"), new DateTimePair("three", "four"));
+        List<OpenPeriod> expected = Arrays.asList(new OpenPeriod(new DateTimePair("one", "two"), new DateTimePair("three", "four")), new OpenPeriod(null, null));
+        List<OpenPeriod> actual = parser.readOpenPeriodsArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readOpeningHoursTest() throws IOException {
+        when(parser.readOpeningHours(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, false);
+        when(reader.nextName()).thenReturn("open_now", "periods", "skip");
+        when(reader.nextBoolean()).thenReturn(true);
+        List<OpenPeriod> periods = Collections.singletonList(new OpenPeriod(new DateTimePair("one", "two"), new DateTimePair("three", "four")));
+        when(parser.readOpenPeriodsArray(reader)).thenReturn(periods);
+        OpenHours expected = new OpenHours(true, periods);
+        OpenHours actual = parser.readOpeningHours(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readGeometryTest() throws IOException {
+        when(parser.readGeometry(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, false);
+        when(reader.nextName()).thenReturn("lat", "lng", "skip");
+        when(reader.nextDouble()).thenReturn(1.0, 2.0);
+        PlaceGeometry expected = new PlaceGeometry(new PlaceLocation(1.0, 2.0));
+        PlaceGeometry actual = parser.readGeometry(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readAddressComponentTypesArrayTest() throws IOException {
+        when(parser.readAddressComponentTypesArray(reader)).thenCallRealMethod();
+
+        // hasNext() should return true N times, where N is the number of AddressComponentTypes
+        int numOfTypes = AddressComponentType.values().length;
+        Boolean[] hasNextValues = new Boolean[numOfTypes + 1];
+        Arrays.fill(hasNextValues, 0, numOfTypes, Boolean.TRUE);
+        hasNextValues[numOfTypes] = Boolean.FALSE; // indicate stop
+        when(reader.hasNext()).thenReturn(true, hasNextValues); // initial true is for "skip"
+
+        String[] types = new String[] {
+                "administrative_area_level_1",
+                "administrative_area_level_2",
+                "administrative_area_level_3",
+                "administrative_area_level_4",
+                "administrative_area_level_5",
+                "colloquial_area",
+                "country",
+                "floor",
+                "geocode",
+                "intersection",
+                "locality",
+                "natural_feature",
+                "neighborhood",
+                "political",
+                "point_of_interest",
+                "post_box",
+                "postal_code",
+                "postal_code_prefix",
+                "postal_code_suffix",
+                "postal_town",
+                "premise",
+                "room",
+                "route",
+                "street_address",
+                "street_number",
+                "sublocality",
+                "sublocality_level_1",
+                "sublocality_level_2",
+                "sublocality_level_3",
+                "sublocality_level_4",
+                "sublocality_level_5",
+                "subpremise",
+                "transit_station"
+        };
+        when(reader.nextString()).thenReturn("skip", types);
+
+        List<AddressComponentType> expected = new ArrayList<>();
+        for (String type : types) {
+            expected.add(AddressComponentType.valueOf(type.toUpperCase()));
+        }
+        List<AddressComponentType> actual = parser.readAddressComponentTypesArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readAddressComponentsArrayTest() throws IOException {
+        when(parser.readAddressComponentsArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, true, true, true, true, false, true, false, false);
+        when(reader.nextName()).thenReturn("long_name", "short_name", "types", "skip");
+        when(reader.nextString()).thenReturn("long", "short");
+        List<AddressComponentType> types = Arrays.asList(AddressComponentType.ROOM, AddressComponentType.FLOOR);
+        when(parser.readAddressComponentTypesArray(reader)).thenReturn(types);
+        List<AddressComponent> expected = Arrays.asList(new AddressComponent("long", "short", types), new AddressComponent(null, null, null));
+        List<AddressComponent> actual = parser.readAddressComponentsArray(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readPlaceDetailsTest() throws IOException {
+        when(parser.readPlaceDetails(reader)).thenCallRealMethod();
+
+        Boolean[] hasNextValues = new Boolean[20];
+        Arrays.fill(hasNextValues, 0, 19, Boolean.TRUE);
+        hasNextValues[19] = Boolean.FALSE;
+        when(reader.hasNext()).thenReturn(true, hasNextValues);
+
+        String[] names = new String[] {
+                "address_components",
+                "formatted_address",
+                "formatted_phone_number",
+                "international_phone_number",
+                "geometry",
+                "icon",
+                "name",
+                "place_id",
+                "opening_hours",
+                "permanently_closed",
+                "photos",
+                "scope",
+                "alt_ids",
+                "price_level",
+                "rating",
+                "reviews",
+                "types",
+                "url",
+                "vicinity"
+        };
+        when(reader.nextName()).thenReturn("skip", names);
+
+        when(parser.readAddressComponentsArray(reader)).thenReturn(Collections.singletonList(new AddressComponent("long", "short", Collections.singletonList(AddressComponentType.ROOM))));
+        when(reader.nextString()).thenReturn("addr", "phone", "intl_phone", "icon", "name", "id", "url", "vic");
+        when(parser.readGeometry(reader)).thenReturn(new PlaceGeometry(new PlaceLocation(1.0, 2.0)));
+        when(parser.readOpeningHours(reader)).thenReturn(new OpenHours(true, Collections.singletonList(new OpenPeriod(new DateTimePair("one", "two"), new DateTimePair("three", "four")))));
+        when(reader.nextBoolean()).thenReturn(true);
+        when(parser.readPhotosArray(reader)).thenReturn(Collections.singletonList(new PlacePhoto(1, 2, "ref")));
+        when(parser.readScope(reader)).thenReturn(PlaceScope.GOOGLE);
+        when(parser.readAltIdsArray(reader)).thenReturn(Collections.singletonList(new AlternativePlaceId("id", PlaceScope.GOOGLE)));
+        when(reader.nextInt()).thenReturn(5);
+        when(reader.nextDouble()).thenReturn(5.0);
+        when(parser.readReviewsArray(reader)).thenReturn(Collections.singletonList(new PlaceReview(Collections.singletonList(new RatingAspect(5, "quality")), "name", "url", "en", 4, "txt", 10L)));
+        when(parser.readTypesArray(reader)).thenReturn(Collections.singletonList("type"));
+
+        PlaceDetails expected = new PlaceDetails(Collections.singletonList(new AddressComponent("long", "short", Collections.singletonList(AddressComponentType.ROOM))),
+                "addr",
+                "phone",
+                "intl_phone",
+                new PlaceGeometry(new PlaceLocation(1.0, 2.0)),
+                "icon",
+                "name",
+                "id",
+                new OpenHours(true, Collections.singletonList(new OpenPeriod(new DateTimePair("one", "two"), new DateTimePair("three", "four")))),
+                true,
+                Collections.singletonList(new PlacePhoto(1, 2, "ref")),
+                PlaceScope.GOOGLE,
+                Collections.singletonList(new AlternativePlaceId("id", PlaceScope.GOOGLE)),
+                5,
+                5.0,
+                Collections.singletonList(new PlaceReview(Collections.singletonList(new RatingAspect(5, "quality")), "name", "url", "en", 4, "txt", 10L)),
+                Collections.singletonList("type"),
+                "url",
+                "vic");
+        PlaceDetails actual = parser.readPlaceDetails(reader);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readPredictionsArrayTest() throws IOException {
+        when(parser.readPredictionsArray(reader)).thenCallRealMethod();
+        when(reader.hasNext()).thenReturn(true, false);
+        Place place = new Place("desc", "id", Collections.singletonList(new MatchedSubstring(1, 2)), Collections.singletonList(new DescriptionTerm(3, "three")), Collections.singletonList(PlaceType.GEOCODE));
+        when(parser.readPlace(reader)).thenReturn(place);
+        List<Place> expected = Collections.singletonList(place);
+        List<Place> actual = parser.readPredictionsArray(reader);
+        assertEquals(expected, actual);
+    }
+}

--- a/placesautocomplete/src/test/java/com/seatgeek/placesautocomplete/json/AndroidPlacesApiJsonWriterTest.java
+++ b/placesautocomplete/src/test/java/com/seatgeek/placesautocomplete/json/AndroidPlacesApiJsonWriterTest.java
@@ -1,0 +1,117 @@
+package com.seatgeek.placesautocomplete.json;
+
+import android.util.JsonWriter;
+
+import com.seatgeek.placesautocomplete.model.DescriptionTerm;
+import com.seatgeek.placesautocomplete.model.MatchedSubstring;
+import com.seatgeek.placesautocomplete.model.Place;
+import com.seatgeek.placesautocomplete.model.PlaceType;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AndroidPlacesApiJsonWriterTest {
+    AndroidPlacesApiJsonParser parser;
+    private JsonWriter writer;
+    private List<String> actual;
+
+    @Before
+    public void setUp() throws IOException {
+        parser = new AndroidPlacesApiJsonParser();
+        writer = mock(JsonWriter.class);
+        actual = new ArrayList<>();
+
+        when(writer.beginArray()).then(new CompositeValueAnswer(BEGIN_ARRAY));
+        when(writer.endArray()).then(new CompositeValueAnswer(END_ARRAY));
+        when(writer.beginObject()).then(new CompositeValueAnswer(BEGIN_OBJECT));
+        when(writer.endObject()).then(new CompositeValueAnswer(END_OBJECT));
+        when(writer.value(anyInt())).then(new ValueAnswer());
+        when(writer.value(anyBoolean())).then(new ValueAnswer());
+        when(writer.value(anyString())).then(new ValueAnswer());
+        when(writer.name(anyString())).then(new ValueAnswer());
+    }
+
+    @Test
+    public void writePlaceTypesArrayTest() throws IOException {
+        List<PlaceType> types = Arrays.asList(PlaceType.ROUTE, PlaceType.GEOCODE);
+        parser.writePlaceTypesArray(writer, types);
+        List<String> expected = Arrays.asList(BEGIN_ARRAY, "route", "geocode", END_ARRAY);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void writeDescriptionTermsArrayTest() throws IOException {
+        List<DescriptionTerm> terms = Arrays.asList(new DescriptionTerm(1, "one"), new DescriptionTerm(2, "two"));
+        parser.writeDescriptionTermsArray(writer, terms);
+        List<String> expected = Arrays.asList(BEGIN_ARRAY, BEGIN_OBJECT, "offset", "1", "value", "one", END_OBJECT, BEGIN_OBJECT, "offset", "2", "value", "two", END_OBJECT, END_ARRAY);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void writeMatchedSubstringsArrayTest() throws IOException {
+        List<MatchedSubstring> substrings = Arrays.asList(new MatchedSubstring(1, 2), new MatchedSubstring(3, 4));
+        parser.writeMatchedSubstringsArray(writer, substrings);
+        List<String> expected = Arrays.asList(BEGIN_ARRAY, BEGIN_OBJECT, "length", "1", "offset", "2", END_OBJECT, BEGIN_OBJECT, "length", "3", "offset", "4", END_OBJECT, END_ARRAY);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void writePlaceTest() throws IOException {
+        Place place = new Place("desc",
+                "id",
+                Collections.singletonList(new MatchedSubstring(1, 2)),
+                Collections.singletonList(new DescriptionTerm(3, "three")),
+                Collections.singletonList(PlaceType.GEOCODE));
+        parser.writePlace(writer, place);
+        List<String> expected = Arrays.asList(BEGIN_OBJECT,
+                "description", "desc",
+                "place_id", "id",
+                "matched_substrings", BEGIN_ARRAY, BEGIN_OBJECT, "length", "1", "offset", "2", END_OBJECT, END_ARRAY,
+                "terms", BEGIN_ARRAY, BEGIN_OBJECT, "offset", "3", "value", "three", END_OBJECT, END_ARRAY,
+                "types", BEGIN_ARRAY, "geocode", END_ARRAY,
+                END_OBJECT);
+        assertEquals(expected, actual);
+    }
+
+    private static String BEGIN_ARRAY = "[";
+    private static String END_ARRAY = "]";
+    private static String BEGIN_OBJECT = "{";
+    private static String END_OBJECT = "}";
+
+    private class CompositeValueAnswer implements Answer<JsonWriter> {
+        private String elem;
+
+        public CompositeValueAnswer(String elem) {
+            this.elem = elem;
+        }
+
+        @Override
+        public JsonWriter answer(InvocationOnMock invocation) throws Throwable {
+            actual.add(elem);
+            return writer;
+        }
+    }
+
+    private class ValueAnswer implements Answer<JsonWriter> {
+        @Override
+        public JsonWriter answer(InvocationOnMock invocation) throws Throwable {
+            actual.add(invocation.getArguments()[0].toString());
+            return writer;
+        }
+    }
+}


### PR DESCRIPTION
I implemented the `AndroidPlacesApiJsonParser` class for anyone that wants to be relieved of the Gson dependency. As you can see, it requires a considerable amount of boilerplate due to the size of the responses being parsed. After writing unit tests and hammering on the demo app, it seems to behave the same as the `GsonPlacesApiJsonParser` class implementation. I ended up overriding `equals` and `hashCode` for several of the model classes to help with testing.

I also went ahead and defined the `PlaceReview` data object, which required me to introduce a `RatingAspect` class to the model.

Hopefully you find this helpful! Let me know if you find any changes you'd like made to the PR.