### PR TITLE
Added country-code support

### DIFF
--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/PlacesApi.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/PlacesApi.java
@@ -190,7 +190,7 @@ public class PlacesApi {
         }
 
         if (countryCode != null) {
-            uriBuilder.appendQueryParameter(PARAMETER_COMPONENT, countryCode);
+            uriBuilder.appendQueryParameter(PARAMETER_COMPONENT, "country:"+countryCode.toUpperCase());
         }
 
         return httpClient.executeAutocompleteRequest(uriBuilder.build());

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/PlacesApi.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/PlacesApi.java
@@ -28,6 +28,7 @@ public class PlacesApi {
     private static final String PARAMETER_RADIUS = "radius";
     private static final String PARAMETER_INPUT = "input";
     private static final String PARAMETER_KEY = "key";
+    private static final String PARAMETER_COMPONENT = "components";
     private static final String PARAMETER_TYPE = "types";
     private static final String PARAMETER_PLACE_ID = "placeid";
     private static final String PARAMETER_LANGUAGE = "language";
@@ -55,6 +56,9 @@ public class PlacesApi {
 
     @Nullable
     private String languageCode;
+
+    @Nullable
+    private String countryCode;
 
     private boolean locationBiasEnabled = true;
 
@@ -136,6 +140,16 @@ public class PlacesApi {
     }
 
     /**
+     * Sets the countryCode code used for autocomplete and place details calls.
+     * List of supportable codes can be seen in <a href="https://developers.google.com/maps/faq#languagesupport">documentation</a>
+     *
+     * @param countryCode the countryCode code
+     */
+    public void setCountryCode(@Nullable String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    /**
      * Performs autocompletion for the given input text and the type of response desired. This is a
      * synchronous call, you must provide your own Async if you need it
      * @param input the textual input that will be autocompleted
@@ -173,6 +187,10 @@ public class PlacesApi {
 
         if (languageCode != null) {
             uriBuilder.appendQueryParameter(PARAMETER_LANGUAGE, languageCode);
+        }
+
+        if (countryCode != null) {
+            uriBuilder.appendQueryParameter(PARAMETER_COMPONENT, countryCode);
         }
 
         return httpClient.executeAutocompleteRequest(uriBuilder.build());

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/PlacesAutocompleteTextView.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/PlacesAutocompleteTextView.java
@@ -57,6 +57,9 @@ public class PlacesAutocompleteTextView extends AppCompatAutoCompleteTextView {
     @Nullable
     private String languageCode;
 
+    @Nullable
+    private String countryCode;
+
     private boolean completionEnabled = true;
 
     private boolean clearEnabled;
@@ -123,6 +126,7 @@ public class PlacesAutocompleteTextView extends AppCompatAutoCompleteTextView {
         String layoutAdapterClass = typedArray.getString(R.styleable.PlacesAutocompleteTextView_pacv_adapterClass);
         String layoutHistoryFile = typedArray.getString(R.styleable.PlacesAutocompleteTextView_pacv_historyFile);
         languageCode = typedArray.getString(R.styleable.PlacesAutocompleteTextView_pacv_languageCode);
+        countryCode = typedArray.getString(R.styleable.PlacesAutocompleteTextView_pacv_countryCode);
         resultType = AutocompleteResultType.fromEnum(typedArray.getInt(R.styleable.PlacesAutocompleteTextView_pacv_resultType, PlacesApi.DEFAULT_RESULT_TYPE.ordinal()));
         clearEnabled = typedArray.getBoolean(R.styleable.PlacesAutocompleteTextView_pacv_clearEnabled, false);
         typedArray.recycle();
@@ -146,6 +150,10 @@ public class PlacesAutocompleteTextView extends AppCompatAutoCompleteTextView {
 
         if (languageCode != null) {
             api.setLanguageCode(languageCode);
+        }
+
+        if (countryCode != null) {
+            api.setCountryCode(countryCode);
         }
 
         if (layoutAdapterClass != null) {

--- a/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/PlacesAutocompleteTextView.java
+++ b/placesautocomplete/src/main/java/com/seatgeek/placesautocomplete/PlacesAutocompleteTextView.java
@@ -508,6 +508,17 @@ public class PlacesAutocompleteTextView extends AppCompatAutoCompleteTextView {
         api.setLanguageCode(this.languageCode);
     }
 
+    /**
+     * Sets the country code used for spanning autocomplete calls.
+     * List of supportable codes can be seen in <a href="https://developers.google.com/maps/faq#languagesupport">documentation</a>
+     *
+     * @param countryCode the countryCode
+     */
+    public void setCountryCode(@Nullable String countryCode) {
+        this.countryCode = countryCode;
+        api.setCountryCode(this.countryCode);
+    }
+
     // Copied from TextInputEditText to ensure extract mode hint works
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {

--- a/placesautocomplete/src/main/res/values/pacv_attrs.xml
+++ b/placesautocomplete/src/main/res/values/pacv_attrs.xml
@@ -13,6 +13,7 @@
             <enum name="establishment" value="2"/>
             <enum name="no_type" value="3"/>
         </attr>
+        <attr name="pacv_countryCode" format="string" />
     </declare-styleable>
 
     <attr name="pacv_placesAutoCompleteTextViewStyle" format="reference"/>


### PR DESCRIPTION
Prior to this PR, there was no way to narrow down autocomplete results by country.
I added a `country_code` attribute to **PlacesAutocompleteTextView** and also included a `setCountryCode()` function to the view class.

When `countryCode` is passed into **PlacesAutocompleteTextView**, it's automatically added as a query parameter to the Uri.